### PR TITLE
Fix github page jquery reference problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 		<link rel="stylesheet" href="css/skeleton.css">
 		<link rel="stylesheet" href="css/index.css">
 		<link rel="icon" type="image/png" href="images/todo-200x200-transparente.png">
-    <script src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="jsencrypt.min.js"></script>
 
 		<script type="text/javascript">


### PR DESCRIPTION
**Qual é o propósito deste Pull Request?**
Corrigir a reference do jquery no github pages usando uma url de cdn.

**O que foi feito para alcançar esse propósito?**
Foi trocada a url de referência no html.

**Como testar se isso realmente funciona?**
Verificar se a mensagem resultante aparece após clicar no botão de encriptar.

**Quem pode ajudar a revisar este PR?**
@thomashs 

**Está fechando alguma issue?**
Ainda não. Resolve apenas o item `Página para crypt com Github.io (MA)` do repo TodoCartoes/card-processor-gateway#69.

**TODO**
- [ ] (ma) Ativar a Github page e repassar o link para os envolvidos (@thomashs ).
