### PR TITLE
Possible solution to create a smaller encrypted message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 ##Cryptonita
 
-This is a simple sandbox to test crypt decrypt strategy with JS at the frontend and Ruby at the backend. A `index.html` page with a Github.io is offered to clients in order to show what we can do in terms of crypt/decrypt!
+This is a simple sandbox to test encrypt decrypt strategy with JS at the frontend and Ruby at the backend. A `index.html` page with a Github.io is offered to clients in order to show what we can do in terms of crypt/decrypt!
+
+### Smaller Encrypted Message Problem
+
+To create a smaller encrypted message you need to generate a private key with less num bits.
+In [JSEncrypt](https://github.com/travist/jsencrypt) doc, when you have to run:
+```
+openssl genrsa -out rsa_1024_priv.pem 1024
+
+```
+You can choose a smaller number of bits. In the case above, we are using the rocommended size 1024.
+Using a 1024 priv key, your encrypted message have the size of 172 chars.
+When using a 256 priv key, your encrypted message have the size of 44 chars.
+This could generate a more 'easy' to decode message, but solves the database field size problem.


### PR DESCRIPTION
**Qual é o propósito deste Pull Request?**
Encontrar uma possível solução para diminuir o tamanho da mensagem encriptada.

**O que foi feito para alcançar esse propósito?**
Testes usando a lib do linux (comando `openssl`), a index page e o .rb do projeto.

**Como testar se isso realmente funciona?**
Gerar chaves privadas de diferentes tamanhos e comparar o número de caracteres dos resultados das mensagens encriptadas resultantes. Isso pode ser feito através de comandos no terminal linux e executando o .rb do projeto (com as variáveis setadas corretamente) - além do auxílio da index page criada para ser exibida para o cliente.
É importante consultar a sequência de passos a ser realizados na documentação do [JSEncrypt](https://github.com/travist/jsencrypt).

**Quem pode ajudar a revisar este PR?**
@thomashs @TomazMartins  

**Está fechando alguma issue?**
Ainda não. Realiza um resolve no o item `"Plano B": buscar uma forma de criptografar com chave privada e pública mas com tamanho reduzido (TS + TM)` do repo TodoCartoes/card-processor-gateway#69.
